### PR TITLE
Spanish support issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,36 @@
-# Making VITS efficient (wip)
+# Making VITS efficient (wip) (spanish support wip)
+
+For spanish preprocessing text:
+```
+python preprocess.py --text_index 1 --text_cleaners spanish_cleaners --filelists /path/to/train/filelist.txt /path/to/val/filelist.txt 
+```
+if you get this warning when preprocessing, ignore it. 
+```
+WARNING:phonemizer:words count mismatch on 100.0% of the lines (1/1)
+WARNING:phonemizer:words count mismatch on 100.0% of the lines (1/1)
+WARNING:phonemizer:words count mismatch on 100.0% of the lines (1/1)
+WARNING:phonemizer:words count mismatch on 100.0% of the lines (1/1)
+WARNING:phonemizer:words count mismatch on 100.0% of the lines (1/1)
+WARNING:phonemizer:words count mismatch on 100.0% of the lines (1/1)
+WARNING:phonemizer:words count mismatch on 100.0% of the lines (1/1)
+WARNING:phonemizer:words count mismatch on 100.0% of the lines (1/1)
+```
+
+
+For training, remember to update the ljs_base.json file in ```configs/ljs_base.json``` with the paths of your training and validation txt files, as well as the text_cleaner to spanish_cleaners.
+
+```
+"name": "your_speaker_name",
+    "training_files": "/path/to/train/filelist.txt",
+    "validation_files": "/path/to/val/filelist.txt",
+    "text_cleaners": ["spanish_cleaners"],
+```
+
+## **FOR NOW THE TRAINING IS NOT WORKING**
+
+The error is in this issue: https://github.com/nivibilla/efficient-vits-finetuning/issues/1
+
+If someone more experienced, wants to collaborate to find a solution in this fork, feel free to do it!
 
 ## Goals
  - [ ] Try to implement LoRA Finetuning on VITS by modifying attentions.py as described in the LoRA Paper

--- a/preprocess.py
+++ b/preprocess.py
@@ -1,25 +1,49 @@
 import argparse
+import re
 import text
 from utils import load_filepaths_and_text
+from phonemizer import phonemize
+from phonemizer.backend import EspeakBackend
+
+def clean_text(text):
+    text = re.sub(r"[^a-zA-ZáéíóúÁÉÍÓÚñÑüÜ'\-.,?!]+", ' ', text)
+    text = text.lower()
+    text = re.sub(r'\s+', ' ', text).strip()
+    return text
+
+def text_to_phonemes(text, backend='espeak'):
+    cleaned_text = clean_text(text)
+    backend_obj = EspeakBackend() if backend == 'espeak' else FestivalBackend()
+    phonemes = phonemize(cleaned_text, language='es', backend=backend_obj)
+    return phonemes
+
+def spanish_cleaners(text):
+    return text_to_phonemes(text, backend='espeak')
+
+def _clean_text(text, text_cleaners):
+    if "spanish_cleaners" in text_cleaners:
+        cleaned_text = spanish_cleaners(text)
+    else:
+        cleaned_text = text._clean_text(text, text_cleaners)
+    return cleaned_text
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser()
-  parser.add_argument("--out_extension", default="cleaned")
-  parser.add_argument("--text_index", default=1, type=int)
-  parser.add_argument("--filelists", nargs="+", default=["filelists/ljs_audio_text_val_filelist.txt", "filelists/ljs_audio_text_test_filelist.txt"])
-  parser.add_argument("--text_cleaners", nargs="+", default=["english_cleaners2"])
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out_extension", default="cleaned")
+    parser.add_argument("--text_index", default=1, type=int)
+    parser.add_argument("--filelists", nargs="+", default=["filelists/ljs_audio_text_val_filelist.txt", "filelists/ljs_audio_text_test_filelist.txt"])
+    parser.add_argument("--text_cleaners", nargs="+", default=["english_cleaners2", "spanish_cleaners"])
 
-  args = parser.parse_args()
-    
+    args = parser.parse_args()
 
-  for filelist in args.filelists:
-    print("START:", filelist)
-    filepaths_and_text = load_filepaths_and_text(filelist)
-    for i in range(len(filepaths_and_text)):
-      original_text = filepaths_and_text[i][args.text_index]
-      cleaned_text = text._clean_text(original_text, args.text_cleaners)
-      filepaths_and_text[i][args.text_index] = cleaned_text
+    for filelist in args.filelists:
+        print("START:", filelist)
+        filepaths_and_text = load_filepaths_and_text(filelist)
+        for i in range(len(filepaths_and_text)):
+            original_text = filepaths_and_text[i][args.text_index]
+            cleaned_text = _clean_text(original_text, args.text_cleaners)
+            filepaths_and_text[i][args.text_index] = cleaned_text
 
-    new_filelist = filelist + "." + args.out_extension
-    with open(new_filelist, "w", encoding="utf-8") as f:
-      f.writelines(["|".join(x) + "\n" for x in filepaths_and_text])
+        new_filelist = filelist + "." + args.out_extension
+        with open(new_filelist, "w", encoding="utf-8") as f:
+            f.writelines(["|".join(x) + "\n" for x in filepaths_and_text])

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ tqdm
 phonemizer
 bitsandbytes
 wandb
+inflect
+num2words

--- a/text/__init__.py
+++ b/text/__init__.py
@@ -1,6 +1,7 @@
 """ from https://github.com/keithito/tacotron """
 from text import cleaners
 from text.symbols import symbols
+from text.cleaners import spanish_cleaners
 
 
 # Mappings from symbol to numeric ID and vice versa:

--- a/text/cleaners.py
+++ b/text/cleaners.py
@@ -2,7 +2,6 @@
 
 '''
 Cleaners are transformations that run over the input text at both training and eval time.
-
 Cleaners can be selected by passing a comma-delimited list of cleaner names as the "cleaners"
 hyperparameter. Some cleaners are English-specific. You'll typically want to use:
   1. "english_cleaners" for English text
@@ -15,7 +14,6 @@ hyperparameter. Some cleaners are English-specific. You'll typically want to use
 import re
 from unidecode import unidecode
 from phonemizer import phonemize
-
 
 # Regular expression matching whitespace:
 _whitespace_re = re.compile(r'\s+')
@@ -96,5 +94,14 @@ def english_cleaners2(text):
   text = lowercase(text)
   text = expand_abbreviations(text)
   phonemes = phonemize(text, language='en-us', backend='espeak', strip=True, preserve_punctuation=True, with_stress=True)
+  phonemes = collapse_whitespace(phonemes)
+  return phonemes
+
+def spanish_cleaners(text):
+  '''Pipeline for Spanish text, including phoneme conversion.'''
+  text = convert_to_ascii(text)
+  text = lowercase(text)
+  text = collapse_whitespace(text)
+  phonemes = phonemize(text, language='es', backend='espeak', strip=True)
   phonemes = collapse_whitespace(phonemes)
   return phonemes

--- a/text/symbols.py
+++ b/text/symbols.py
@@ -1,16 +1,12 @@
-""" from https://github.com/keithito/tacotron """
-
-'''
-Defines the set of symbols used in text input to the model.
-'''
 _pad        = '_'
 _punctuation = ';:,.!?¡¿—…"«»“” '
 _letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+_accented_letters = 'ÁÉÍÓÚáéíóúÝýÀÈÌÒÙàèìòùÂÊÎÔÛâêîôûÄËÏÖÜäëïöüÑñ'
 _letters_ipa = "ɑɐɒæɓʙβɔɕçɗɖðʤəɘɚɛɜɝɞɟʄɡɠɢʛɦɧħɥʜɨɪʝɭɬɫɮʟɱɯɰŋɳɲɴøɵɸθœɶʘɹɺɾɻʀʁɽʂʃʈʧʉʊʋⱱʌɣɤʍχʎʏʑʐʒʔʡʕʢǀǁǂǃˈˌːˑʼʴʰʱʲʷˠˤ˞↓↑→↗↘'̩'ᵻ"
-
+_numbers = '0123456789'
 
 # Export all symbols:
-symbols = [_pad] + list(_punctuation) + list(_letters) + list(_letters_ipa)
+symbols = [_pad] + list(_punctuation) + list(_letters) + list(_accented_letters) + list(_letters_ipa) + list(_numbers)
 
 # Special symbol ids
 SPACE_ID = symbols.index(" ")


### PR DESCRIPTION
To do a fine-tuning using LJSpeech dataset, it is not necessary to modify symbols.py, since accents and umlauts (áäéëíïóöúü) are already supported by the phonemizer (espeak-ng), therefore I think it is better to revert the changes, including the __init__.py file. To add support for Spanish, I've simply created a new attribute called spanish_cleaners in cleaner.py:
def spanish_cleaners(text):
  '''Pipeline for Spanish text (using phonemes)'''
  text = convert_to_ascii(text)
  phonemes = phonemize(text, language='es', backend='espeak', strip=True, preserve_punctuation=True, with_stress=True, punctuation_marks = ';:,.!?¡¿—…"«»“”()', language_switch='remove-flags')
  phonemes = collapse_whitespace(phonemes)
  phonemes = phonemes.strip()
  return phonemes
